### PR TITLE
Github Actions now build 2 apks

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,12 +28,12 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: dappstore_systemapp_debug.apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: app/build/outputs/apk/system/app-system-debug.apk
     - name: Build Regular APK with Gradle
       run: ./gradlew assembleRegularDebug
     - name: Publish User-App APK
       uses: actions/upload-artifact@master
       with:
         name: dappstore_userapp_debug.apk
-        path: app/build/outputs/apk/debug/app-debug.apk
+        path: app/build/outputs/apk/regular/app-regular-debug.apk
     

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -24,8 +24,18 @@ jobs:
       run: chmod +x gradlew
     - name: Build Debug APK with Gradle
       run: ./gradlew assembleDebug
-    - name: Publish APK
+    - name: Publish System-App APK
       uses: actions/upload-artifact@master
       with:
-        name: dappstore_debug.apk
+        name: dappstore_systemapp_debug.apk
         path: app/build/outputs/apk/debug/app-debug.apk
+    - name: Change to user-app (without system privileges)
+      run: sed -i '5d' app/src/main/AndroidManifest.xml
+    - name: Build Debug APK with Gradle
+      run: ./gradlew assembleDebug
+    - name: Publish User-App APK
+      uses: actions/upload-artifact@master
+      with:
+        name: dappstore_userapp_debug.apk
+        path: app/build/outputs/apk/debug/app-debug.apk
+    

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -2,7 +2,7 @@ name: Android CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, testMultipleBuids ]
   pull_request:
     branches: [ main ]
 

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,12 +28,12 @@ jobs:
       uses: actions/upload-artifact@master
       with:
         name: dappstore_systemapp_debug.apk
-        path: app/build/outputs/apk/system/app-system-debug.apk
+        path: ./app/build/outputs/apk/system/debug/app-system-debug.apk
     - name: Build Regular APK with Gradle
       run: ./gradlew assembleRegularDebug
     - name: Publish User-App APK
       uses: actions/upload-artifact@master
       with:
         name: dappstore_userapp_debug.apk
-        path: app/build/outputs/apk/regular/app-regular-debug.apk
+        path: ./app/build/outputs/apk/regular/debug/app-regular-debug.apk
     

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -22,17 +22,15 @@ jobs:
 
     - name: Grant execute permission for gradlew
       run: chmod +x gradlew
-    - name: Build Debug APK with Gradle
-      run: ./gradlew assembleDebug
+    - name: Build System-App APK with Gradle
+      run: ./gradlew assembleSystemDebug
     - name: Publish System-App APK
       uses: actions/upload-artifact@master
       with:
         name: dappstore_systemapp_debug.apk
         path: app/build/outputs/apk/debug/app-debug.apk
-    - name: Change to user-app (without system privileges)
-      run: sed -i '5d' app/src/main/AndroidManifest.xml
-    - name: Build Debug APK with Gradle
-      run: ./gradlew assembleDebug
+    - name: Build Regular APK with Gradle
+      run: ./gradlew assembleRegularDebug
     - name: Publish User-App APK
       uses: actions/upload-artifact@master
       with:

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -18,7 +18,20 @@ android {
         vectorDrawables {
             useSupportLibrary true
         }
+        manifestPlaceholders["userID"] = "android.uid.system"
     }
+    flavorDimensions "version"
+    productFlavors {
+        system {
+            dimension = "version"
+            manifestPlaceholders["userID"] = "android.uid.system"
+        }
+        regular {
+            dimension = "version"
+            manifestPlaceholders["userID"] = ""
+        }
+    }
+
 
     buildTypes {
         release {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,7 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.ethereum.dappstore"
-    android:sharedUserId="android.uid.system"
+    android:sharedUserId="${userID}"
     >
 
     <uses-permission android:name="android.permission.INTERNET"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -2,7 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     package="org.ethereum.dappstore"
-    android:sharedUserId="android.uid.system" >
+    android:sharedUserId="android.uid.system"
+    >
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/app/src/main/java/org/ethereum/dappstore/logic/AppDownloader.kt
+++ b/app/src/main/java/org/ethereum/dappstore/logic/AppDownloader.kt
@@ -126,7 +126,7 @@ class AppDownloader {
             val successString = pr.inputStream.bufferedReader().use { it.readLine() }
 
             println("Error: $errorString")
-            print("Success: $successString")
+            println("Success: $successString")
             if (successString.startsWith("Success")) {
                 Toast.makeText(context, "Successfully installed ${info.name}", Toast.LENGTH_SHORT).show()
             } else {


### PR DESCRIPTION
It builds 2 apks, one that can be used as a system-app, and an apk which can be installed just like a user-app.
Also made installing also work on non-ethOS devices. 
For the 2 builds, essentially it is the same code, but for the user-app build it removes the `sharedUserId` which is necessary for system-apps.